### PR TITLE
Add WNYC mobile app agents

### DIFF
--- a/db/agents.yml
+++ b/db/agents.yml
@@ -315,6 +315,14 @@ agents:
     name: uTorrent
     type: Desktop App # and mobile???
     os: null
+  - regex: ^WNYC.+Android
+    name: WNYC App
+    type: Mobile App
+    os: Android
+  - regex: ^WNYC.+(Darwin|iPhone|iOS)
+    name: WNYC App
+    type: Mobile App
+    os: iOS
   - regex: ^Winamp
     name: Winamp
     type: Desktop App


### PR DESCRIPTION
I'm not sure if PRX is accepting pull requests here, but NYPR is utilizing this regex list for analytics.
The WNYC mobile applications provide access to PRX content, so I figured it may be worthwhile to both parties to include our agents in the list.

If it's not useful to PRX to include this agent, just let me know, we can maintain a fork!

---

The WNYC mobile app went through several variations before settling on
a User-Agent format. This commit should catch the following formats...

**Android (Current)**
```
WNYC App/3.0.3 Android/25 device/ZTE-ZTE B2017G
WNYC App/3.0.3 Android/23 device/samsung-SM-G900T3
WNYC App/3.0.3 Android/23 device/samsung-SAMSUNG-SM-J120AZ
```

**Android (Legacy)**
```
WNYC/3.0.0 Android/23 device/samsung-SAMSUNG-SM-G930A
WNYC/3.0.0 Android/23 device/CUBOT-CUBOT_NOTE_S
WNYC/3.0.0 Android/24 device/Verizon-SM-G930V
```

**iOS (Current)**
```
WNYC App/3.0.23-11121 iOS/11.4 device/iPhone8,1
WNYC App/3.0.26-11126 iOS/11.4.1 device/iPhone8,1
WNYC App/3.0.21-11116 iOS/9.3.3 device/iPhone8,4
```

**iOS (Legacy)**
```
WNYC 2.1.20 rv:11043 (iPhone; iPhone OS 8.0; en_US)
WNYC 2.1.20 rv:11043 (iPad; iPhone OS 9.2; fr_FR)
WNYC/11113 CFNetwork/887 Darwin/17.0.0
```