### PR TITLE
Add Luminary agent

### DIFF
--- a/db/agents.lock.yml
+++ b/db/agents.lock.yml
@@ -186,6 +186,9 @@ agents:
   - regex: ^LibVLC.+Android
     type: '36'
     os: '42'
+  - regex: '^Luminary\/[0-9\.]+'
+    name: '91'
+    type: '36'
   - regex: ^MediaMonkey 4
     name: '71'
     type: '35'
@@ -697,3 +700,4 @@ tags:
   '88': '''sodes'
   '89': WBEZ App
   '90': Wilson FM
+  '91': Luminary

--- a/db/agents.yml
+++ b/db/agents.yml
@@ -203,6 +203,10 @@ agents:
     name: null
     type: Mobile App
     os: Android
+  - regex: ^Luminary\/[0-9\.]+
+    name: Luminary
+    type: Mobile App
+    os: null
   - regex: ^MediaMonkey 4
     name: MediaMonkey
     type: Desktop App

--- a/test/support/testagents.csv
+++ b/test/support/testagents.csv
@@ -15999,3 +15999,4 @@ AndroidDownloadManager/8.1.0 (Linux; U; Android 8.1.0; A502DL Build/OPM1.171019.
 "Podbean/Android App 6.8.0 (http://podbean.com),f40a092e001120375656a1e92c369c4e",14
 Spotify/8.4.90 Android/24 (SM-A510F),14
 "Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG-SM-G891A Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/72.0.3626.105 Mobile Safari/537.36 GSA/9.21.5.21.arm64",14
+Luminary/1.0,14


### PR DESCRIPTION
A relatively new podcast client called "Luminary" is building a userbase.
They operate on a subscription model but the Luminary client can pull content from public RSS feeds as well.
https://luminarypodcasts.com/

The current User-Agent is OS-agnostic and simply represented as:
```
Luminary/1.0
```

I added `Luminary/1.0` to the CSV of test agents and it looks like that updated `db/agents.lock.yml`. I'm assuming that the `count` column in the CSV was generated by processing source data that falls outside of this repository. As a result I just set an arbitrary number next to the Luminary line, but let me know if I should do something else!