### PR TITLE
Pandora desktop

### DIFF
--- a/db/agents.json
+++ b/db/agents.json
@@ -841,6 +841,24 @@
       ]
     },
     {
+      "regex": "^Mozilla.+Windows.+PandoraApp",
+      "name": "Pandora",
+      "type": "Desktop App",
+      "os": "Windows",
+      "examples": [
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.128 Electron/4.2.10 Safari/537.36 PandoraApp/15.0.2"
+      ]
+    },
+    {
+      "regex": "^Mozilla.+Macintosh.+PandoraApp",
+      "name": "Pandora",
+      "type": "Desktop App",
+      "os": "macOS",
+      "examples": [
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.128 Electron/4.2.10 Safari/537.36 PandoraApp/15.0.1"
+      ]
+    },
+    {
       "regex": "^Playapod.+CFNetwork",
       "name": "Playapod",
       "type": "Mobile App",

--- a/db/agents.lock.js
+++ b/db/agents.lock.js
@@ -86,6 +86,8 @@ exports.agents = [
   [/^Pandora.+Android/, 82, 36, 42],
   [/^Mozilla.+(iPad|iPhone).+Pandora/, 82, 36, 43],
   [/^Pandora.+CFNetwork/, 82, 36, 43],
+  [/^Mozilla.+Windows.+PandoraApp/, 82, 35, 41],
+  [/^Mozilla.+Macintosh.+PandoraApp/, 82, 35, 45],
   [/^Playapod.+CFNetwork/, 112, 36, 43],
   [/^Playapod.+Android/, 112, 36, 42],
   [/^Player( |%20)FM.+CFNetwork/, 15, 36, 43],

--- a/db/agents.lock.json
+++ b/db/agents.lock.json
@@ -503,6 +503,18 @@
       "os": "43"
     },
     {
+      "regex": "^Mozilla.+Windows.+PandoraApp",
+      "name": "82",
+      "type": "35",
+      "os": "41"
+    },
+    {
+      "regex": "^Mozilla.+Macintosh.+PandoraApp",
+      "name": "82",
+      "type": "35",
+      "os": "45"
+    },
+    {
       "regex": "^Playapod.+CFNetwork",
       "name": "112",
       "type": "36",

--- a/db/agents.lock.yml
+++ b/db/agents.lock.yml
@@ -327,6 +327,14 @@ agents:
     name: '82'
     type: '36'
     os: '43'
+  - regex: ^Mozilla.+Windows.+PandoraApp
+    name: '82'
+    type: '35'
+    os: '41'
+  - regex: ^Mozilla.+Macintosh.+PandoraApp
+    name: '82'
+    type: '35'
+    os: '45'
   - regex: ^Playapod.+CFNetwork
     name: '112'
     type: '36'

--- a/db/agents.yml
+++ b/db/agents.yml
@@ -574,6 +574,18 @@ agents:
     examples:
       - Pandora/19081002 CFNetwork/978.0.7 Darwin/18.6.0
       - Pandora/2100 CFNetwork/978.0.7 Darwin/18.6.0
+  - regex: '^Mozilla.+Windows.+PandoraApp'
+    name: Pandora
+    type: Desktop App
+    os: Windows
+    examples:
+      - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.128 Electron/4.2.10 Safari/537.36 PandoraApp/15.0.2
+  - regex: '^Mozilla.+Macintosh.+PandoraApp'
+    name: Pandora
+    type: Desktop App
+    os: macOS
+    examples:
+      - Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.128 Electron/4.2.10 Safari/537.36 PandoraApp/15.0.1
   - regex: '^Playapod.+CFNetwork'
     name: Playapod
     type: Mobile App

--- a/docs/index.html
+++ b/docs/index.html
@@ -632,14 +632,6 @@ Luminary/70 CFNetwork/978.0.7 Darwin/18.6.0
       </div>
       <div class="card">
         <div class="card-body">
-          <h5 class="card-title"><code>/^Luminary\/1.0/</code></h5>
-          <h6 class="card-subtitle mb2">
-          </h6><code class="examples">Luminary/1.0
-</code>
-        </div>
-      </div>
-      <div class="card">
-        <div class="card-body">
           <h5 class="card-title"><code>/^MediaMonkey 4/</code></h5>
           <h6 class="card-subtitle mb2"><span class="badge badge-pill badge-primary">MediaMonkey</span><span class="badge badge-pill badge-success">Desktop App</span><span class="badge badge-pill badge-info">Windows</span>
           </h6><code class="examples">MediaMonkey 4.1.12.1798
@@ -761,6 +753,22 @@ Mozilla/5.0 (iPad; CPU OS 12_1_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, lik
           <h6 class="card-subtitle mb2"><span class="badge badge-pill badge-primary">Pandora</span><span class="badge badge-pill badge-success">Mobile App</span><span class="badge badge-pill badge-info">iOS</span>
           </h6><code class="examples">Pandora/19081002 CFNetwork/978.0.7 Darwin/18.6.0
 Pandora/2100 CFNetwork/978.0.7 Darwin/18.6.0
+</code>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-body">
+          <h5 class="card-title"><code>/^Mozilla.+Windows.+PandoraApp/</code></h5>
+          <h6 class="card-subtitle mb2"><span class="badge badge-pill badge-primary">Pandora</span><span class="badge badge-pill badge-success">Desktop App</span><span class="badge badge-pill badge-info">Windows</span>
+          </h6><code class="examples">Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.128 Electron/4.2.10 Safari/537.36 PandoraApp/15.0.2
+</code>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-body">
+          <h5 class="card-title"><code>/^Mozilla.+Macintosh.+PandoraApp/</code></h5>
+          <h6 class="card-subtitle mb2"><span class="badge badge-pill badge-primary">Pandora</span><span class="badge badge-pill badge-success">Desktop App</span><span class="badge badge-pill badge-info">macOS</span>
+          </h6><code class="examples">Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.128 Electron/4.2.10 Safari/537.36 PandoraApp/15.0.1
 </code>
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prx-podagent",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "User-agent parser for common podcast clients",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
https://www.theverge.com/2019/11/12/20959222/pandora-podcasts-now-available-website-desktop-app