### PR TITLE
Add PRX embed player app

### DIFF
--- a/db/agents.json
+++ b/db/agents.json
@@ -1310,7 +1310,7 @@
     },
     {
       "regex": "^play\\.prx\\.org",
-      "name": "PRX Embed Player",
+      "name": "PRX Play",
       "notes": [
         "Embeddable play.prx.org audio player"
       ],

--- a/db/agents.json
+++ b/db/agents.json
@@ -1309,6 +1309,16 @@
       ]
     },
     {
+      "regex": "^play\\.prx\\.org",
+      "name": "PRX Embed Player",
+      "notes": [
+        "Embeddable play.prx.org audio player"
+      ],
+      "examples": [
+        "play.prx.org"
+      ]
+    },
+    {
       "regex": "^RadioPublic Android|^RadioPublic\\/android",
       "name": "RadioPublic",
       "type": "Mobile App",

--- a/db/agents.lock.js
+++ b/db/agents.lock.js
@@ -133,6 +133,7 @@ exports.agents = [
   [/^Podkicker/, 20, 36, 42],
   [/^PRI\/.+CFNetwork/, 114, 36, 43],
   [/^Pro[Cc]ast.+(iOS|CFNetwork)/, 83, 36, 43],
+  [/^play\.prx\.org/, 142, null, null],
   [/^RadioPublic Android|^RadioPublic\/android/, 21, 36, 42],
   [/^RadioPublic iOS|^RadioPublic.+CFNetwork|^RadioPublic\/iOS/, 21, 36, 43],
   [/^ReactNativeVideo.+Android/, null, 36, 42],
@@ -378,5 +379,6 @@ exports.tags = {
   138: 'castget',
   139: 'Newsboat',
   140: 'Anghami',
-  141: 'VLC'
+  141: 'VLC',
+  142: 'PRX Embed Player'
 };

--- a/db/agents.lock.js
+++ b/db/agents.lock.js
@@ -380,5 +380,5 @@ exports.tags = {
   139: 'Newsboat',
   140: 'Anghami',
   141: 'VLC',
-  142: 'PRX Embed Player'
+  142: 'PRX Play'
 };

--- a/db/agents.lock.json
+++ b/db/agents.lock.json
@@ -1514,6 +1514,6 @@
     "139": "Newsboat",
     "140": "Anghami",
     "141": "VLC",
-    "142": "PRX Embed Player"
+    "142": "PRX Play"
   }
 }

--- a/db/agents.lock.json
+++ b/db/agents.lock.json
@@ -776,6 +776,10 @@
       "os": "43"
     },
     {
+      "regex": "^play\\.prx\\.org",
+      "name": "142"
+    },
+    {
       "regex": "^RadioPublic Android|^RadioPublic\\/android",
       "name": "21",
       "type": "36",
@@ -1509,6 +1513,7 @@
     "138": "castget",
     "139": "Newsboat",
     "140": "Anghami",
-    "141": "VLC"
+    "141": "VLC",
+    "142": "PRX Embed Player"
   }
 }

--- a/db/agents.lock.yml
+++ b/db/agents.lock.yml
@@ -506,6 +506,8 @@ agents:
     name: '83'
     type: '36'
     os: '43'
+  - regex: ^play\.prx\.org
+    name: '142'
   - regex: ^RadioPublic Android|^RadioPublic\/android
     name: '21'
     type: '36'
@@ -1036,3 +1038,4 @@ tags:
   '139': Newsboat
   '140': Anghami
   '141': VLC
+  '142': PRX Embed Player

--- a/db/agents.lock.yml
+++ b/db/agents.lock.yml
@@ -1038,4 +1038,4 @@ tags:
   '139': Newsboat
   '140': Anghami
   '141': VLC
-  '142': PRX Embed Player
+  '142': PRX Play

--- a/db/agents.yml
+++ b/db/agents.yml
@@ -901,7 +901,7 @@ agents:
       - Procast (iOS)
       - ProCast/1 CFNetwork/976 Darwin/18.2.0
   - regex: '^play\.prx\.org'
-    name: PRX Embed Player
+    name: PRX Play
     notes:
       - Embeddable play.prx.org audio player
     examples:

--- a/db/agents.yml
+++ b/db/agents.yml
@@ -900,6 +900,12 @@ agents:
     examples:
       - Procast (iOS)
       - ProCast/1 CFNetwork/976 Darwin/18.2.0
+  - regex: '^play\.prx\.org'
+    name: PRX Embed Player
+    notes:
+      - Embeddable play.prx.org audio player
+    examples:
+      - play.prx.org
   - regex: '^RadioPublic Android|^RadioPublic\/android'
     name: RadioPublic
     type: Mobile App

--- a/docs/index.html
+++ b/docs/index.html
@@ -1176,7 +1176,7 @@ ProCast/1 CFNetwork/976 Darwin/18.2.0
       <div class="card">
         <div class="card-body">
           <h5 class="card-title"><code>/^play\.prx\.org/</code></h5>
-          <h6 class="card-subtitle mb2"><span class="badge badge-pill badge-primary">PRX Embed Player</span>
+          <h6 class="card-subtitle mb2"><span class="badge badge-pill badge-primary">PRX Play</span>
           </h6>
           <p class="card-text">Embeddable play.prx.org audio player</p><code class="examples">play.prx.org
 </code>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1175,6 +1175,15 @@ ProCast/1 CFNetwork/976 Darwin/18.2.0
       </div>
       <div class="card">
         <div class="card-body">
+          <h5 class="card-title"><code>/^play\.prx\.org/</code></h5>
+          <h6 class="card-subtitle mb2"><span class="badge badge-pill badge-primary">PRX Embed Player</span>
+          </h6>
+          <p class="card-text">Embeddable play.prx.org audio player</p><code class="examples">play.prx.org
+</code>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-body">
           <h5 class="card-title"><code>/^RadioPublic Android|^RadioPublic\/android/</code></h5>
           <h6 class="card-subtitle mb2"><span class="badge badge-pill badge-primary">RadioPublic</span><span class="badge badge-pill badge-success">Mobile App</span><span class="badge badge-pill badge-info">Android</span>
           </h6><code class="examples">RadioPublic/android-1.11


### PR DESCRIPTION
The PRX Embed Player adds a `_from=play.prx.org` to all requests.

Mark that as `name = "PRX Embed Player"`, but leave the type/os blank so they inherit from the UserAgent header.

Or should I have called this `PRX Embeddable Player` instead?  Or `Play.prx.org`?  This will show up in Metrics and Augury-targeting.