### PR TITLE
Identify query param listennetwork traffic

### DIFF
--- a/db/agents.json
+++ b/db/agents.json
@@ -878,6 +878,16 @@
       ]
     },
     {
+      "regex": "^listennetwork",
+      "name": "Listen Network",
+      "notes": [
+        "Query param \"?_from=\" traffic - https://www.listennetwork.co/"
+      ],
+      "examples": [
+        "listennetwork"
+      ]
+    },
+    {
       "regex": "^Luminary.+(iOS|CFNetwork)",
       "name": "Luminary",
       "type": "Mobile App",
@@ -1413,7 +1423,7 @@
       "regex": "^play\\.prx\\.org",
       "name": "PRX Play",
       "notes": [
-        "Embeddable play.prx.org audio player"
+        "Query param \"?_from=\" traffic - https://play.prx.org"
       ],
       "examples": [
         "play.prx.org"

--- a/db/agents.lock.js
+++ b/db/agents.lock.js
@@ -87,6 +87,7 @@ exports.agents = [
   [/^Lavf/, null, 35, null],
   [/^Laughable.+iOS/, 54, 36, 43],
   [/^(LG-|LM-|Player).+LG Player.+Android/, null, 36, 42],
+  [/^listennetwork/, 155, null, null],
   [/^Luminary.+(iOS|CFNetwork)/, 91, 36, 43],
   [/^Luminary.+Android/, 91, 36, 42],
   [/^MediaMonkey/, 71, 35, 41],
@@ -414,5 +415,6 @@ exports.tags = {
   151: 'CPR App',
   152: 'Storybutton',
   153: 'WPR App',
-  154: 'WUNC App'
+  154: 'WUNC App',
+  155: 'Listen Network'
 };

--- a/db/agents.lock.json
+++ b/db/agents.lock.json
@@ -507,6 +507,10 @@
       "os": "42"
     },
     {
+      "regex": "^listennetwork",
+      "name": "155"
+    },
+    {
       "regex": "^Luminary.+(iOS|CFNetwork)",
       "name": "91",
       "type": "36",
@@ -1649,6 +1653,7 @@
     "151": "CPR App",
     "152": "Storybutton",
     "153": "WPR App",
-    "154": "WUNC App"
+    "154": "WUNC App",
+    "155": "Listen Network"
   }
 }

--- a/db/agents.lock.yml
+++ b/db/agents.lock.yml
@@ -329,6 +329,8 @@ agents:
   - regex: ^(LG-|LM-|Player).+LG Player.+Android
     type: '36'
     os: '42'
+  - regex: ^listennetwork
+    name: '155'
   - regex: ^Luminary.+(iOS|CFNetwork)
     name: '91'
     type: '36'
@@ -1132,3 +1134,4 @@ tags:
   '152': Storybutton
   '153': WPR App
   '154': WUNC App
+  '155': Listen Network

--- a/db/agents.yml
+++ b/db/agents.yml
@@ -607,6 +607,12 @@ agents:
       - Player/LG Player 1.0 for Android 7.0 (stagefright alternative),
       - LM-G710/V10o Player/LG Player 1.0 for Android 8.0.0 (stagefright alternative)
       - LG-H872/V20g Player/LG Player 1.0 for Android 8.0.0 (stagefright alternative)
+  - regex: '^listennetwork'
+    name: Listen Network
+    notes:
+      - Query param "?_from=" traffic - https://www.listennetwork.co/
+    examples:
+      - listennetwork
   - regex: '^Luminary.+(iOS|CFNetwork)'
     name: Luminary
     type: Mobile App
@@ -974,7 +980,7 @@ agents:
   - regex: '^play\.prx\.org'
     name: PRX Play
     notes:
-      - Embeddable play.prx.org audio player
+      - Query param "?_from=" traffic - https://play.prx.org
     examples:
       - play.prx.org
   - regex: '^Radio thmanyah.+Android'

--- a/docs/index.html
+++ b/docs/index.html
@@ -791,6 +791,15 @@ LG-H872/V20g Player/LG Player 1.0 for Android 8.0.0 (stagefright alternative)
       </div>
       <div class="card">
         <div class="card-body">
+          <h5 class="card-title"><code>/^listennetwork/</code></h5>
+          <h6 class="card-subtitle mb2"><span class="badge badge-pill badge-primary">Listen Network</span>
+          </h6>
+          <p class="card-text">Query param &quot;?_from=&quot; traffic - https://www.listennetwork.co/</p><code class="examples">listennetwork
+</code>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-body">
           <h5 class="card-title"><code>/^Luminary.+(iOS|CFNetwork)/</code></h5>
           <h6 class="card-subtitle mb2"><span class="badge badge-pill badge-primary">Luminary</span><span class="badge badge-pill badge-success">Mobile App</span><span class="badge badge-pill badge-info">iOS</span>
           </h6><code class="examples">Luminary/0.0.243 build 3326/iOS 12.2
@@ -1268,7 +1277,7 @@ ProCast/1 CFNetwork/976 Darwin/18.2.0
           <h5 class="card-title"><code>/^play\.prx\.org/</code></h5>
           <h6 class="card-subtitle mb2"><span class="badge badge-pill badge-primary">PRX Play</span>
           </h6>
-          <p class="card-text">Embeddable play.prx.org audio player</p><code class="examples">play.prx.org
+          <p class="card-text">Query param &quot;?_from=&quot; traffic - https://play.prx.org</p><code class="examples">play.prx.org
 </code>
         </div>
       </div>


### PR DESCRIPTION
Seeing some `?_from=listennetwork` requests, with UAs like `https://adtech-gaburieru4649.vercel.app/`.

Also clarifying that these regexps match against that `_from` param alone... not the `referrer + from` we tend to store in the db `remote_referrer` field.